### PR TITLE
Revert "fix: allow all methods and origins (while not using public api)"

### DIFF
--- a/noise_api/api/main.py
+++ b/noise_api/api/main.py
@@ -1,6 +1,5 @@
 import uvicorn
 from fastapi import FastAPI
-from fastapi.middleware.cors import CORSMiddleware 
 
 from noise_api.api.endpoints import router as tasks_router
 from noise_api.config import settings
@@ -12,20 +11,6 @@ app = FastAPI(
     title=settings.title,
     descriprition=settings.description,
     version=settings.version,
-)
-
-origins = [
-    # "http://localhost",
-    # "http://localhost:8080",
-    "*"
-]
-
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=origins,
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
 )
 
 


### PR DESCRIPTION
Reverts digitalcityscience/COUP-noise-api-v2#8